### PR TITLE
Fixed windows path seperater issues.

### DIFF
--- a/lib/parse-config.js
+++ b/lib/parse-config.js
@@ -119,8 +119,8 @@ module.exports = function (path) {
             sync: boolean(incomingConfig.sync, false)
         };
 
-        if (result.routesPath.charAt(result.routesPath.length - 1) !== path.sep) {
-            result.routesPath += path.sep;
+        if (result.routesPath.charAt(result.routesPath.length - 1) !== path.posix.sep) {
+            result.routesPath += path.posix.sep;
         }
 
         return result;

--- a/spec/parse-config.spec.js
+++ b/spec/parse-config.spec.js
@@ -39,7 +39,8 @@ describe("parseConfig", function () {
         var pathMock;
 
         pathMock = {
-            sep: "/"
+            sep: "/",
+            posix: { sep: "/", }
         };
         parseConfig= require("../lib/parse-config")(pathMock);
         propertyToTest = null;
@@ -126,6 +127,21 @@ describe("parseConfig", function () {
         });
         it("errors when a non-string value is passed", function () {
             expect(propTesterError([])).toThrow();
+        });
+        
+        describe("windows", function() {
+            beforeEach(function () {
+                var pathMock = {
+                    sep: "\\",
+                    posix: { sep: "/", }
+                };
+                parseConfig = require("../lib/parse-config")(pathMock);
+            });
+
+            it("allows any string",
+                function() {
+                    propTester("asdfasdf/");
+                });
         });
     });
     describe(".sync", function () {


### PR DESCRIPTION
Parse-config used the platform path seperator, however file paths were posix style path.